### PR TITLE
relax Expronicon for ZXCalculus

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 YaoLocations = "66df03fb-d475-48f7-b449-3d9064bf085b"
 
 [compat]
-Expronicon = "0.6"
+Expronicon = "0.10"
 MLStyle = "0.4"
 YaoLocations = "0.1"
 julia = "1.6"


### PR DESCRIPTION
Hello, could you please relax the version requirement for `Expronicon.jl`? I need the latest version to work on `ZXCalculus.jl`. I ran the test and it passed with no error. 

If possible, could you please also bump the version? Thanks a lot!