### PR TITLE
Feat/fix printing of IRCode

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -63,3 +63,11 @@ function Base.show(io::IO, ::MIME"text/plain", g::Chain)
     print(io, ")")
 end
 
+function Base.show(io::IO, x::IRCode)
+  if x.stmts.stmt[1] isa Core.ReturnNode
+     printstyled(io, nothing)
+  else
+    printstyled(io, x)
+  end
+end
+


### PR DESCRIPTION
Previous wrong output
```
 1 ─     return nothing                                                                    │
 , 3, Chain(YaoHIR.Gate(H, Locations(1)), YaoHIR.Gate(H, Locations(2)), YaoHIR.Gate(X, Locations(3)), YaoHIR.Gate(H, Locations(3)), YaoHIR.Ctrl(YaoHIR.Gate(X, Locations(3)), CtrlLocations(1)), YaoHIR.Gate(H, Locations(1)), YaoHIR.Ctrl(YaoHIR.Gate(X, Locations(3)), CtrlLocations(2)), YaoHIR.Gate(H, Locations(2))))
```


Correct Output
```
Chain(Gate(X, Locations(1)), %1, Ctrl(Gate(:(%1), Locations(3)), CtrlLocations(2)))Test Summary: | Pass  Total  Time
bir = BlockIR(nothing, 3, Chain(Gate(H, Locations(1)), Gate(H, Locations(2)), Gate(X, Locations(3)), Gate(H, Locations(3)), Ctrl(Gate(X, Locations(3)), CtrlLocations(1)), Gate(H, Locations(1)), Ctrl(Gate(X, Locations(3)), CtrlLocations(2)), Gate(H, Locations(2))))
```